### PR TITLE
Fix terminal output being cut off by 'Claude is working' status panel

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -90,21 +90,13 @@ export const SessionView = memo(() => {
           {hook.isLoadingOutput && (
             <div className="absolute top-4 left-4 text-gray-600 dark:text-gray-400 z-10">Loading output...</div>
           )}
-          <div className={`bg-gray-50 dark:bg-black h-full ${hook.viewMode === 'output' ? 'block' : 'hidden'} relative`}>
-            <div ref={terminalRef} className="h-full" />
-            {hook.loadError && hook.viewMode === 'output' && (
-              <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center">
-                <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 shadow-lg">
-                  <p className="text-gray-700 dark:text-gray-300 mb-2">Failed to load output content</p>
-                  <p className="text-gray-600 dark:text-gray-500 text-sm mb-4">{hook.loadError}</p>
-                  <button onClick={() => hook.loadOutputContent(activeSession.id)} className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
-                    Reload Output
-                  </button>
-                </div>
-              </div>
-            )}
+          <div className={`bg-gray-50 dark:bg-black h-full ${hook.viewMode === 'output' ? 'flex flex-col' : 'hidden'} relative`}>
+            <div 
+              ref={terminalRef} 
+              className="flex-1 min-h-0"
+            />
             {(activeSession.status === 'running' || activeSession.status === 'initializing') && (
-              <div className="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-2">
+              <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-2 flex-shrink-0">
                 <div className="flex items-center justify-between text-gray-700 dark:text-gray-300">
                     <div className="flex items-center space-x-3">
                         <div className="flex space-x-1">
@@ -124,6 +116,17 @@ export const SessionView = memo(() => {
                             Cancel
                         </button>
                     </div>
+                </div>
+              </div>
+            )}
+            {hook.loadError && hook.viewMode === 'output' && (
+              <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center">
+                <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 shadow-lg">
+                  <p className="text-gray-700 dark:text-gray-300 mb-2">Failed to load output content</p>
+                  <p className="text-gray-600 dark:text-gray-500 text-sm mb-4">{hook.loadError}</p>
+                  <button onClick={() => hook.loadOutputContent(activeSession.id)} className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+                    Reload Output
+                  </button>
                 </div>
               </div>
             )}

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -859,6 +859,17 @@ export const useSessionView = (
     return () => observer.disconnect();
   }, [terminalRef, viewMode]);
 
+  // Trigger terminal resize when session status changes (for padding adjustment)
+  useEffect(() => {
+    if (viewMode === 'output' && fitAddon.current && activeSession) {
+      // Small delay to ensure DOM updates have completed
+      const timer = setTimeout(() => {
+        fitAddon.current?.fit();
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [activeSession?.status, viewMode]);
+
   useEffect(() => {
     if (terminalInstance.current) terminalInstance.current.options.theme = theme === 'light' ? lightTheme : darkTheme;
     if (scriptTerminalInstance.current) scriptTerminalInstance.current.options.theme = theme === 'light' ? lightTheme : scriptDarkTheme;


### PR DESCRIPTION
## Summary
- Fixes issue where the "Claude is working..." status panel cuts off terminal output
- Refactored layout from absolute positioning to flexbox
- Ensures all terminal content remains visible when Claude is processing

## Problem
When Claude is working, the status panel at the bottom of the output view was absolutely positioned and overlapping the terminal content, cutting off the last few lines of output. This made it impossible to see the most recent output while Claude was processing.

## Solution  
Refactored the output view to use flexbox layout instead of absolute positioning. The terminal now uses flex-1 to take available space, and the status panel is a flex item that pushes content up rather than overlaying it.

## Changes Made
- **SessionView.tsx**: Changed output container from block to flex layout, made terminal use flex-1 with min-h-0
- **useSessionView.ts**: Added resize trigger when session status changes to ensure proper terminal sizing

## Screenshots
[Add your before/after screenshots here]

## Test Plan
- [x] Start Crystal app
- [x] Select or create a session
- [x] Send a prompt to Claude
- [x] Verify "Claude is working..." panel appears without cutting off output
- [x] Verify terminal resizes properly when status changes
- [x] Test with different terminal content lengths
- [x] Verify no visual regressions in other views