### PR TITLE
feat: disable status change notifications by default for better UX

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -15,7 +15,7 @@ export function useNotifications() {
   const settings = useRef<NotificationSettings>({
     enabled: true,
     playSound: true,
-    notifyOnStatusChange: true,
+    notifyOnStatusChange: false,
     notifyOnWaiting: true,
     notifyOnComplete: true,
   });


### PR DESCRIPTION
## Summary
- Changes the default value of `notifyOnStatusChange` from `true` to `false`
- Improves the out-of-box notification experience for new users
- Preserves all functionality for users who prefer verbose notifications

## Motivation
When creating a new session, users currently receive two notifications in quick succession:
1. "New Session Created" when the session initializes
2. "Status Update" when it transitions to running (~100ms later)

This can be confusing for new users as it creates notification noise for user-initiated actions. The rapid double-chime makes it seem like something unexpected happened.

## Changes
This PR makes a single line change to set `notifyOnStatusChange: false` by default in the notification settings.

### What this means:
- **Default behavior**: Users only get notifications for events that need their attention:
  - ✅ Session waiting for input
  - ✅ Session completed
  - ✅ Session errors
- **Power users**: Can still enable status change notifications in settings if they want verbose feedback
- **No breaking changes**: All existing functionality remains available

## Testing
- Created new sessions and verified only one notification sound on creation
- Verified waiting/completion/error notifications still work
- Tested that enabling the setting in preferences restores the original behavior

## Alternative Considered
I initially implemented a more complex solution to track newly created sessions and skip just the initializing→running transition, but realized that simply changing the default provides a cleaner solution that respects user preferences.